### PR TITLE
Use ApacheCommons predicate and more efficient processing - all on Java7

### DIFF
--- a/weckzeitfinder/pom.xml
+++ b/weckzeitfinder/pom.xml
@@ -82,5 +82,12 @@
 			<scope>compile</scope>
 		</dependency>
 
+		<dependency>
+			<groupId>org.apache.commons</groupId>
+			<artifactId>commons-collections4</artifactId>
+			<version>4.1</version>
+			<scope>compile</scope>
+		</dependency>
+
 	</dependencies>
 </project>

--- a/weckzeitfinder/pom.xml
+++ b/weckzeitfinder/pom.xml
@@ -15,8 +15,8 @@
 				<artifactId>maven-compiler-plugin</artifactId>
 				<version>2.0.2</version>
 				<configuration>
-					<source>1.8</source>
-					<target>1.8</target>
+					<source>1.7</source>
+					<target>1.7</target>
 				</configuration>
 			</plugin>
 			<plugin>

--- a/weckzeitfinder/src/main/java/com/penguineering/snuselpi/SummaryInclusionPredicate.java
+++ b/weckzeitfinder/src/main/java/com/penguineering/snuselpi/SummaryInclusionPredicate.java
@@ -1,0 +1,87 @@
+package com.penguineering.snuselpi;
+
+import org.apache.commons.collections4.Predicate;
+
+import net.fortuna.ical4j.model.Component;
+import net.fortuna.ical4j.model.Property;
+import net.jcip.annotations.Immutable;
+
+/**
+ * Inclusion predicate for calendar events based on their summary.
+ *
+ * <p>
+ * The summary may never be null.
+ * </p>
+ *
+ * @author Stefan Haun <tux@netz39.de>
+ */
+@Immutable
+public class SummaryInclusionPredicate implements Predicate<Component> {
+	/**
+	 * Get an instance of the inclusion predicate based on the summary.
+	 *
+	 * @param summary
+	 *            The VEVENT summary.
+	 * @return true if the VEVENT has an equal summary, otherwise false
+	 * @throws NullPointerException
+	 *             if the summary argument is null.
+	 */
+	public static SummaryInclusionPredicate getInstance(String summary) throws NullPointerException {
+		if (summary == null)
+			throw new NullPointerException("Summary must not be null!");
+
+		return new SummaryInclusionPredicate(summary);
+	}
+
+	/**
+	 * This property must not be null!
+	 */
+	private String summary;
+
+	/**
+	 * Hide the constructor.
+	 */
+	private SummaryInclusionPredicate(String summary) {
+		this.summary = summary;
+	}
+
+	/**
+	 * Get the summary.
+	 *
+	 * @return The summary that will match a VEVENT.
+	 */
+	public String getSummary() {
+		return summary;
+	}
+
+	/**
+	 * Match the {@link Component}'s summary with the summary property.
+	 */
+	@Override
+	public boolean evaluate(Component component) {
+		final String sum = component.getProperties().getProperty(Property.SUMMARY).getValue();
+		return summary.equals(sum);
+	}
+
+	@Override
+	public int hashCode() {
+		final int prime = 31;
+		int result = 1;
+		// summary cannot be null
+		result = prime * result + summary.hashCode();
+		return result;
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		if (this == obj)
+			return true;
+		if (obj == null)
+			return false;
+		if (getClass() != obj.getClass())
+			return false;
+		SummaryInclusionPredicate other = (SummaryInclusionPredicate) obj;
+		// summary cannot be null
+		return summary.equals(other.summary);
+	}
+}

--- a/weckzeitfinder/src/main/java/com/penguineering/snuselpi/Weckzeitfinder.java
+++ b/weckzeitfinder/src/main/java/com/penguineering/snuselpi/Weckzeitfinder.java
@@ -138,11 +138,10 @@ public class Weckzeitfinder {
 			try {
 				final Calendar calendar = builder.build(fin);
 
-				for (final Component component : calendar.getComponents()) {
-					final boolean componentIsVEVENT = component.getName().equals(Component.VEVENT);
-					// check if the component is a VEVENT
-					// and matches the inclusion predicate
-					if (componentIsVEVENT && inclPred.evaluate(component)) {
+				// iterate all VEVENT components
+				for (final Component component : calendar.getComponents(Component.VEVENT)) {
+					// check if the component matches the inclusion predicate
+					if (inclPred.evaluate(component)) {
 						final boolean hasFailed = retrieveCalendarEvents(component, period, evtBF, events, null);
 
 						if (hasFailed)


### PR DESCRIPTION
Java 8 scheint noch nicht so wirklich verbreitet zu sein, deshalb würde ich das gern vermeiden – sonst schränken wir gleich die Laufzeitumgebungen für die Software ein.

Ich habe die Apache Commons Collections als Dependency eingefügt und damit ein SummaryInclusionPredicate geschrieben, das Components anhand ihrer Summary matcht.

Außerdem werden jetzt nur VEVENT components zurückgegeben und diese vor der Recurrence Expansion auf die Summary gematcht. Sonst wird viel berechnet, das dann doch wieder wegfliegt.
